### PR TITLE
docs: specifying v1.x version of prom/prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Modify: `/prometheus-data/prometheus.yml`, replace `192.168.0.10` with your own 
 Host machine IP address: `ifconfig | grep 'inet 192'| awk '{ print $2}'`
 
 ```sh
-docker run -p 9090:9090 -v "$(pwd)/prometheus-data":/prometheus-data prom/prometheus -config.file=/prometheus-data/prometheus.yml
+docker run -p 9090:9090 -v "$(pwd)/prometheus-data":/prometheus-data prom/prometheus:v1.8.2 -config.file=/prometheus-data/prometheus.yml
 ```
 
 Open Prometheus: [http://localhost:9090](http://localhost:9090/graph)


### PR DESCRIPTION
An alternative resolution for issue #6, related to _prom/prometheus_ v1.x.x having a different schema for `rules` than the latest _prom/prometheus_ v2.x.x iterations.

Potentially, this fix could be tagged in a `v1` branch, and PR #8 could be applied after in the `master` branch.